### PR TITLE
Integrate Stripe checkout flow for marketplace tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Ensure you supply `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` when running mi
 
 ## Edge & background services
 - **Cloudflare Pages Functions middleware** injects runtime environment variables (`SUPABASE_URL`, `SUPABASE_ANON_KEY`) into the browser at request time so the client can hydrate on the edge without bundling secrets.【F:functions/_middleware.ts†L1-L62】
+- **Stripe checkout handler** – a Pages API route brokers secure Checkout Session creation with Stripe using per-environment secrets configured in Wrangler.【F:functions/api/stripe/checkout.ts†L1-L192】【F:wrangler.toml†L1-L11】
 - **Supabase Edge Function** `send-contact-email` handles contact form submissions with strict schema validation (Zod), rate limiting, sanitisation, database persistence, and bilingual autoresponder emails via Resend.【F:supabase/functions/send-contact-email/index.ts†L1-L183】
 
 ## Performance, security & compliance
@@ -81,7 +82,7 @@ The application is pre-tuned for high-traffic scenarios, with detailed tracking 
    ```
 3. **Configure environment variables**
    - Duplicate `.env.local` and populate with your Supabase project keys using the `SUPABASE_` names.
-   - Update `wrangler.toml` with matching `SUPABASE_URL` and `SUPABASE_ANON_KEY` values for Cloudflare Pages deployments.【F:src/integrations/supabase/client.ts†L210-L266】【F:wrangler.toml†L1-L10】
+   - Update `wrangler.toml` with matching `SUPABASE_URL`, `SUPABASE_ANON_KEY`, and `STRIPE_SECRET_KEY` values for Cloudflare Pages deployments.【F:src/integrations/supabase/client.ts†L210-L266】【F:wrangler.toml†L1-L11】
 4. **Start the dev server**
    ```bash
    yarn dev

--- a/functions/api/stripe/checkout.ts
+++ b/functions/api/stripe/checkout.ts
@@ -1,0 +1,253 @@
+const JSON_HEADERS = {
+  "content-type": "application/json; charset=utf-8",
+  "cache-control": "no-store",
+} as const;
+
+interface StripeCheckoutRequest {
+  subscriptionId?: string;
+  toolId?: string;
+  toolName?: string;
+  priceCents?: number;
+  currency?: string;
+  pricingType?: "one_time" | "subscription";
+  paymentReference?: string;
+  metadata?: Record<string, unknown>;
+  buyerEmail?: string;
+  billingInterval?: "day" | "week" | "month" | "year";
+  successUrl?: string;
+  cancelUrl?: string;
+  trialPeriodDays?: number;
+  clientReferenceId?: string;
+}
+
+interface StripeCheckoutResponseBody {
+  checkoutUrl?: string;
+  sessionId?: string;
+  paymentIntentId?: string | null;
+  stripeSubscriptionId?: string | null;
+  clientSecret?: string | null;
+}
+
+interface ErrorBody {
+  error: string;
+  details?: unknown;
+}
+
+const createErrorResponse = (status: number, body: ErrorBody) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: JSON_HEADERS,
+  });
+
+const parseRequest = async (request: Request): Promise<StripeCheckoutRequest> => {
+  try {
+    return (await request.json()) as StripeCheckoutRequest;
+  } catch (error) {
+    throw createErrorResponse(400, {
+      error: "Invalid JSON body",
+      details: error instanceof Error ? error.message : String(error),
+    });
+  }
+};
+
+const serializeMetadata = (metadata: Record<string, unknown> | undefined) => {
+  const params = new URLSearchParams();
+
+  if (!metadata) {
+    return params;
+  }
+
+  Object.entries(metadata).forEach(([key, value]) => {
+    if (value === undefined || value === null) {
+      return;
+    }
+
+    const normalizedKey = key.replace(/[^a-zA-Z0-9_]/g, "_");
+    params.set(`metadata[${normalizedKey}]`, String(value));
+  });
+
+  return params;
+};
+
+const withBaseMetadata = (input: StripeCheckoutRequest) => {
+  const params = new URLSearchParams();
+
+  if (input.subscriptionId) {
+    params.set("metadata[subscription_id]", input.subscriptionId);
+  }
+
+  if (input.toolId) {
+    params.set("metadata[tool_id]", input.toolId);
+  }
+
+  if (input.paymentReference) {
+    params.set("metadata[payment_reference]", input.paymentReference);
+  }
+
+  return params;
+};
+
+const appendParams = (target: URLSearchParams, source: URLSearchParams) => {
+  for (const [key, value] of source.entries()) {
+    target.set(key, value);
+  }
+};
+
+const normalizeCurrency = (currency?: string) => currency?.toLowerCase() ?? "usd";
+
+const sanitizeInterval = (
+  interval?: string,
+): "day" | "week" | "month" | "year" => {
+  switch ((interval ?? "month").toLowerCase()) {
+    case "day":
+    case "week":
+    case "year":
+      return interval.toLowerCase() as "day" | "week" | "year";
+    default:
+      return "month";
+  }
+};
+
+const sanitizeTrialPeriod = (trialPeriodDays?: number) => {
+  if (typeof trialPeriodDays !== "number" || Number.isNaN(trialPeriodDays)) {
+    return undefined;
+  }
+
+  if (trialPeriodDays <= 0) {
+    return undefined;
+  }
+
+  return Math.floor(trialPeriodDays);
+};
+
+const buildCheckoutPayload = (input: Required<
+  Pick<StripeCheckoutRequest, "priceCents" | "currency" | "pricingType" | "toolName">
+> &
+  StripeCheckoutRequest) => {
+  const params = new URLSearchParams();
+
+  params.set("success_url", input.successUrl ?? "https://promptbazaar.ai/tools?checkout=success");
+  params.set("cancel_url", input.cancelUrl ?? "https://promptbazaar.ai/tools?checkout=cancelled");
+  params.set("mode", input.pricingType === "subscription" ? "subscription" : "payment");
+  params.set("line_items[0][quantity]", "1");
+  params.set("line_items[0][price_data][currency]", normalizeCurrency(input.currency));
+  params.set("line_items[0][price_data][product_data][name]", input.toolName);
+  params.set("line_items[0][price_data][unit_amount]", String(input.priceCents));
+
+  if (input.pricingType === "subscription") {
+    const interval = sanitizeInterval(input.billingInterval);
+    params.set("line_items[0][price_data][recurring][interval]", interval);
+
+    const normalizedTrial = sanitizeTrialPeriod(input.trialPeriodDays);
+    if (typeof normalizedTrial === "number") {
+      params.set("subscription_data[trial_period_days]", String(normalizedTrial));
+    }
+  }
+
+  if (input.buyerEmail) {
+    params.set("customer_email", input.buyerEmail);
+  }
+
+  if (input.clientReferenceId) {
+    params.set("client_reference_id", input.clientReferenceId);
+  }
+
+  appendParams(params, withBaseMetadata(input));
+  appendParams(params, serializeMetadata(input.metadata));
+
+  return params;
+};
+
+const createStripeCheckoutSession = async (
+  secretKey: string,
+  payload: StripeCheckoutRequest,
+): Promise<StripeCheckoutResponseBody> => {
+  const priceCents = payload.priceCents;
+  const currency = payload.currency;
+  const pricingType = payload.pricingType;
+  const toolName = payload.toolName;
+
+  if (
+    typeof priceCents !== "number" ||
+    Number.isNaN(priceCents) ||
+    priceCents <= 0 ||
+    typeof currency !== "string" ||
+    typeof pricingType !== "string" ||
+    typeof toolName !== "string" ||
+    toolName.length === 0
+  ) {
+    throw createErrorResponse(400, {
+      error: "Missing or invalid payment fields",
+    });
+  }
+
+  const body = buildCheckoutPayload({
+    ...payload,
+    priceCents,
+    currency,
+    pricingType,
+    toolName,
+  });
+
+  const response = await fetch("https://api.stripe.com/v1/checkout/sessions", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${secretKey}`,
+      "content-type": "application/x-www-form-urlencoded;charset=UTF-8",
+    },
+    body,
+  });
+
+  const json = (await response.json()) as Record<string, unknown>;
+
+  if (!response.ok) {
+    throw createErrorResponse(response.status, {
+      error:
+        typeof json?.error === "object" && json.error && "message" in json.error
+          ? String((json.error as { message?: unknown }).message ?? "Stripe error")
+          : "Failed to create Stripe checkout session",
+      details: json,
+    });
+  }
+
+  return {
+    checkoutUrl: typeof json.url === "string" ? json.url : undefined,
+    sessionId: typeof json.id === "string" ? json.id : undefined,
+    paymentIntentId:
+      typeof json.payment_intent === "string" ? json.payment_intent : null,
+    stripeSubscriptionId:
+      typeof json.subscription === "string" ? json.subscription : null,
+    clientSecret: typeof json.client_secret === "string" ? json.client_secret : null,
+  };
+};
+
+export const onRequestPost = async ({ request, env }: { request: Request; env: Record<string, string | undefined> }) => {
+  if (request.method !== "POST") {
+    return createErrorResponse(405, { error: "Method not allowed" });
+  }
+
+  const secretKey = env?.STRIPE_SECRET_KEY;
+
+  if (!secretKey) {
+    return createErrorResponse(500, { error: "Stripe secret key is not configured" });
+  }
+
+  try {
+    const payload = await parseRequest(request);
+    const result = await createStripeCheckoutSession(secretKey, payload);
+
+    return new Response(JSON.stringify(result satisfies StripeCheckoutResponseBody), {
+      status: 200,
+      headers: JSON_HEADERS,
+    });
+  } catch (error) {
+    if (error instanceof Response) {
+      return error;
+    }
+
+    return createErrorResponse(500, {
+      error: "Unexpected error while creating checkout session",
+      details: error instanceof Error ? error.message : String(error),
+    });
+  }
+};

--- a/src/utils/payments/types.ts
+++ b/src/utils/payments/types.ts
@@ -26,6 +26,8 @@ export interface SubscriptionCheckoutInput extends BaseCheckoutInput {
   pricingType: "subscription";
   currentPeriodEnd?: string;
   trialEndsAt?: string;
+  billingInterval?: "day" | "week" | "month" | "year";
+  trialPeriodDays?: number | null;
 }
 
 export type CheckoutInput = OneTimeCheckoutInput | SubscriptionCheckoutInput;
@@ -34,6 +36,9 @@ export interface CheckoutResponse {
   subscription: Tables<"tool_subscriptions">;
   checkoutUrl?: string;
   clientSecret?: string;
+  stripeSessionId?: string;
+  stripePaymentIntentId?: string | null;
+  stripeSubscriptionId?: string | null;
 }
 
 export interface SubscriptionAccessCheck {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -5,7 +5,9 @@ pages_build_output_dir = "dist"
 [vars]
 # MY_VARIABLE = "production_value"
 SUPABASE_URL = "https://mnqkeoeikfjwlgyowsnb.supabase.co"
+STRIPE_SECRET_KEY = "sk_test_replace_me"
 
 [env.production.vars]
 # MY_VARIABLE = "production_value"
 SUPABASE_URL = "https://mnqkeoeikfjwlgyowsnb.supabase.co"
+STRIPE_SECRET_KEY = "sk_live_replace_me"


### PR DESCRIPTION
## Summary
- add a Cloudflare Pages API route that creates Stripe Checkout Sessions with environment-driven credentials
- extend the payments checkout utilities to request Stripe sessions, persist Stripe metadata, and surface new response fields
- update the tools marketplace purchase handler to pass billing interval and trial information and document the Stripe setup in the README
- introduce a marketplace hero CTA that triggers the Stripe checkout flow with consistent styling

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68d42695e06883269a93ebeaf1fad4d2